### PR TITLE
build: Look for Dockerfile in build context dir

### DIFF
--- a/cli/up/build.go
+++ b/cli/up/build.go
@@ -203,10 +203,13 @@ func (cmd *up) prePushBaseImages(services composeTypes.Services) (<-chan baseIma
 	baseImages := map[string]string{}
 
 	for _, svc := range services {
-		dockerfilePath := svc.Build.Dockerfile
-		if dockerfilePath == "" {
-			dockerfilePath = "Dockerfile"
+		dockerfile := svc.Build.Dockerfile
+		if dockerfile == "" {
+			dockerfile = "Dockerfile"
 		}
+
+		dockerfilePath := filepath.Join(filepath.Dir(cmd.composePath),
+			svc.Build.Context, dockerfile)
 
 		baseImageName, err := cmd.getBaseImage(dockerfilePath)
 		if err != nil {


### PR DESCRIPTION
Otherwise, we fail to load the Dockerfile when using -f or when the build
context is not ".".