### PR TITLE
up: Fix value in log message

### DIFF
--- a/cli/up/build.go
+++ b/cli/up/build.go
@@ -80,7 +80,7 @@ func (cmd *up) buildImages(composeFile composeTypes.Config) (map[string]string, 
 		// version.
 		imageID, ok := cmd.getCachedImage(svc.Name)
 		if ok {
-			log.WithField("service", svc).
+			log.WithField("service", svc.Name).
 				WithField("id", imageID).
 				Debug("Skipping build and using cached version")
 		} else {


### PR DESCRIPTION
We printed the full service struct before rather than just the service's
name.


**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #

**How this PR was tested:**