### PR TITLE
build: Give better error on nonexistent Dockerfile

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -47,6 +47,21 @@ func Build(dockerClient *client.Client, absComposePath, svc string, spec compose
 		opts.Dockerfile = "Dockerfile"
 	}
 
+	dockerfilePath := filepath.Join(filepath.Dir(absComposePath),
+		spec.Context, opts.Dockerfile)
+	stat, err := os.Stat(dockerfilePath)
+	if err != nil {
+		return "", errors.NewFriendlyError(
+			"Can't open Dockerfile for %s, please make sure it exists and can be accessed.\n"+
+				"The Dockerfile should be at the path %s.\nThe underlying error was: %v",
+			svc, dockerfilePath, err)
+	}
+	if !stat.Mode().IsRegular() {
+		return "", errors.NewFriendlyError(
+			"The Dockerfile for %s (%s) is not a regular file.",
+			svc, dockerfilePath)
+	}
+
 	contextPath := filepath.Join(
 		filepath.Dir(absComposePath),
 		spec.Context)


### PR DESCRIPTION
Before, the docker daemon would return an error, but this could be confusing.
This change explicitly checks that the correct Dockerfile is accessible before
starting the build, so that we can provide a more helpful error that includes
the path we checked.