### PR TITLE
compose: Support "bind volumes" specified via DriverOpts

### DIFF
--- a/cli/up/up.go
+++ b/cli/up/up.go
@@ -444,6 +444,15 @@ func (cmd *up) makeSyncthingClient(dcCfg composeTypes.Config) syncthing.Client {
 			allVolumes = append(allVolumes, volume)
 		}
 	}
+
+	for _, namedVol := range dcCfg.Volumes {
+		source, ok := dockercompose.ParseNamedBindVolume(namedVol)
+
+		if ok {
+			allVolumes = append(allVolumes, syncthing.BindVolume{LocalPath: source})
+		}
+	}
+
 	return syncthing.NewClient(allVolumes)
 }
 

--- a/pkg/dockercompose/dockercompose.go
+++ b/pkg/dockercompose/dockercompose.go
@@ -290,3 +290,22 @@ func load(det types.ConfigDetails, opts ...func(opts *loader.Options)) (cfg *typ
 	cfg, err = loader.Load(det, opts...)
 	return
 }
+
+func ParseNamedBindVolume(vol types.VolumeConfig) (source string, ok bool) {
+	if vol.Driver != "" && vol.Driver != "local" {
+		return "", false
+	}
+
+	// Look for -o bind.
+	mountOpts, ok := vol.DriverOpts["o"]
+	if !ok {
+		mountOpts = vol.DriverOpts["options"]
+	}
+	for _, opt := range strings.Split(mountOpts, ",") {
+		if opt == "bind" {
+			return vol.DriverOpts["device"], true
+		}
+	}
+
+	return "", false
+}


### PR DESCRIPTION
This adds support for manual bind mounts as named volumes specified as described
in https://github.com/docker/compose/issues/2957.