### PR TITLE
login: Use different hostname for login-proxy GRPC endpoint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,26 +3,6 @@ run:
   concurrency: 2
 
 linters:
-  enable-all: true
   disable:
-    - dogsled
-    - exhaustive
-    - funlen
-    - gochecknoglobals
-    - gochecknoinits
-    - gocognit
-    - gocyclo
-    - godox
-    - goerr113
-    - gofumpt
-    - gomnd
-    - gosec
-    - interfacer
-    - maligned
-    - noctx
-    - prealloc
     - staticcheck
-    - testpackage
     - vetshadow
-    - whitespace
-    - wsl

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-LOGIN_PROXY_HOSTNAME ?= blimp-login.kelda.io
+LOGIN_PROXY_GRPC_HOSTNAME ?= blimp-login-grpc.kelda.io
 CLUSTER_MANAGER_HOST ?= blimp-manager.kelda.io:443
 VERSION?=latest
 MANAGER_CERT_PATH = "./certs/cluster-manager.crt.pem"
 LD_FLAGS = "-X github.com/kelda/blimp/pkg/version.Version=${VERSION} \
 	   -X github.com/kelda/blimp/cli/manager.ClusterManagerCertBase64=$(shell base64 ${MANAGER_CERT_PATH} | tr -d "\n") \
-	   -X github.com/kelda/blimp/cli/login.LoginProxyHost=${LOGIN_PROXY_HOSTNAME} \
+	   -X github.com/kelda/blimp/cli/login.LoginProxyGRPCHost=${LOGIN_PROXY_GRPC_HOSTNAME} \
 	   -X github.com/kelda/blimp/cli/manager.DefaultManagerHost=${CLUSTER_MANAGER_HOST} \
 	   -s -w"
 

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -18,8 +18,8 @@ import (
 	"github.com/kelda/blimp/pkg/proto/login"
 )
 
-// LoginProxyHost is set by make.
-var LoginProxyHost = ""
+// LoginProxyGRPCHost is set by make.
+var LoginProxyGRPCHost = ""
 
 func New() *cobra.Command {
 	return &cobra.Command{
@@ -52,7 +52,7 @@ Kelda Blimp only uses your login to identify you, and doesn't pull any other inf
 func getAuthToken() (string, error) {
 	// Use the system's default certificate pool.
 	tlsConfig := &tls.Config{}
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", LoginProxyHost, auth.LoginProxyGRPCPort),
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", LoginProxyGRPCHost, auth.LoginProxyGRPCPort),
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithUnaryInterceptor(errors.UnaryClientInterceptor),
 	)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -27,7 +27,7 @@ const (
 	AuthURL            = AuthHost + "/authorize"
 	TokenURL           = AuthHost + "/oauth/token"
 	JWKSURL            = "https://blimp-testing.auth0.com/.well-known/jwks.json"
-	LoginProxyGRPCPort = 444
+	LoginProxyGRPCPort = 443
 )
 
 var Endpoint = oauth2.Endpoint{


### PR DESCRIPTION
This allows use from networks where non-standard ports might be blocked.