### PR TITLE
config: Allow overriding manager host/cert and kubeapi host

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -51,7 +51,7 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use: "blimp",
 
-		PersistentPreRun:  setupAnalytics,
+		PersistentPreRun:  setup,
 		PersistentPostRun: closeManager,
 
 		// The call to rootCmd.Execute prints the error, so we silence errors
@@ -80,14 +80,14 @@ func main() {
 	}
 }
 
-func setupAnalytics(cmd *cobra.Command, _ []string) {
-	if err := manager.SetupClient(); err != nil {
-		log.WithError(err).Fatal("Failed to connect to the Blimp cluster")
-	}
-
+func setup(cmd *cobra.Command, _ []string) {
 	cfg, err := cfgdir.ParseConfig()
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read blimp config")
+	}
+
+	if err := manager.SetupClient(cfg.ManagerHost, cfg.ManagerCert); err != nil {
+		log.WithError(err).Fatal("Failed to connect to the Blimp cluster")
 	}
 
 	if cfg.OptOutAnalytics {

--- a/cli/up/up.go
+++ b/cli/up/up.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kelda/blimp/cli/manager"
 	"github.com/kelda/blimp/cli/util"
 	"github.com/kelda/blimp/pkg/analytics"
+	"github.com/kelda/blimp/pkg/cfgdir"
 	"github.com/kelda/blimp/pkg/docker"
 	"github.com/kelda/blimp/pkg/dockercompose"
 	"github.com/kelda/blimp/pkg/errors"
@@ -196,7 +197,7 @@ func (cmd *up) run(services []string) error {
 		return err
 	}
 
-	nodeConn, err := util.Dial(cmd.nodeAddr, cmd.nodeCert)
+	nodeConn, err := util.Dial(cmd.nodeAddr, cmd.nodeCert, "")
 	if err != nil {
 		return err
 	}
@@ -335,7 +336,11 @@ func (cmd *up) createSandbox(composeCfg string, idPathMap map[string]string) err
 	// Save the Kubernetes API credentials for use by other Blimp commands.
 	kubeCreds := resp.GetKubeCredentials()
 	cmd.auth.KubeToken = kubeCreds.Token
-	cmd.auth.KubeHost = kubeCreds.Host
+	if cfgdir.KubeHostOverride != "" {
+		cmd.auth.KubeHost = cfgdir.KubeHostOverride
+	} else {
+		cmd.auth.KubeHost = kubeCreds.Host
+	}
 	cmd.auth.KubeCACrt = kubeCreds.CaCrt
 	cmd.auth.KubeNamespace = kubeCreds.Namespace
 	if err := cmd.auth.Save(); err != nil {

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -17,14 +17,14 @@ import (
 	"github.com/kelda/blimp/pkg/errors"
 )
 
-func Dial(addr, certPEM string) (*grpc.ClientConn, error) {
+func Dial(addr, certPEM, serverNameOverride string) (*grpc.ClientConn, error) {
 	cp := x509.NewCertPool()
 	if !cp.AppendCertsFromPEM([]byte(certPEM)) {
 		return nil, errors.New("failed to parse cert")
 	}
 
 	return grpc.Dial(addr,
-		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(cp, "")),
+		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(cp, serverNameOverride)),
 		// AWS ELBs close connections that are inactive for 60s, so we set a
 		// keepalive interval lower than this.
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 30 * time.Second}),

--- a/pkg/cfgdir/cfgdir.go
+++ b/pkg/cfgdir/cfgdir.go
@@ -14,9 +14,13 @@ import (
 
 type Config struct {
 	OptOutAnalytics bool `json:"opt_out_analytics"`
+
+	KubeHost    string `json:"kube_host"`
+	ManagerHost string `json:"manager_host"`
+	ManagerCert string `json:"manager_cert"`
 }
 
-var ConfigDir string
+var ConfigDir, KubeHostOverride string
 
 func init() {
 	var err error
@@ -56,5 +60,10 @@ func ParseConfig() (Config, error) {
 	if err := yaml.Unmarshal(cfgContents, &cfg); err != nil {
 		return Config{}, errors.WithContext("parse config", err)
 	}
+
+	if cfg.KubeHost != "" {
+		KubeHostOverride = cfg.KubeHost
+	}
+
 	return cfg, nil
 }


### PR DESCRIPTION
This allows you to point blimp at another backend server (e.g. a self-hosted
version) without recompiling.