### PR TITLE
docker: Print log message before creating context

### DIFF
--- a/pkg/build/docker/docker.go
+++ b/pkg/build/docker/docker.go
@@ -165,12 +165,12 @@ func (c client) BuildAndPush(images map[string]build.BuildPushConfig) (pushedIma
 }
 
 func (c *client) build(serviceName, imageName string, opts build.BuildPushConfig) error {
+	fmt.Printf("Building image for %s...\n", serviceName)
 	buildContextTar, err := makeTar(opts.Context)
 	if err != nil {
 		return errors.WithContext("tar context", err)
 	}
 
-	fmt.Printf("Building image for %s...\n", serviceName)
 	buildResp, err := c.client.ImageBuild(context.TODO(), buildContextTar, types.ImageBuildOptions{
 		Tags:        []string{imageName},
 		Dockerfile:  opts.Dockerfile,


### PR DESCRIPTION
Creating the context can be slow with large build contexts.


**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #

**How this PR was tested:**