### PR TITLE
up: Print log message after containers boot

### DIFF
--- a/cli/up/status.go
+++ b/cli/up/status.go
@@ -63,6 +63,7 @@ func (sp *statusPrinter) Run(ctx context.Context,
 		}
 
 		if allReady {
+			fmt.Println(goterm.Color("All containers successfully started", goterm.GREEN))
 			return true
 		}
 
@@ -73,8 +74,7 @@ func (sp *statusPrinter) Run(ctx context.Context,
 			// Continue.
 		}
 	}
-	fmt.Println(goterm.Color("All containers successfully started", goterm.GREEN))
-	return true
+	panic("unreached")
 }
 
 func (sp *statusPrinter) syncStatus(ctx context.Context,


### PR DESCRIPTION
A recent commit accidentally caused it to not get printed. It's used in
the integration tests to tell when the services have booted.


**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #

**How this PR was tested:**