### PR TITLE
circle: Always push to :latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LD_FLAGS = "-X github.com/kelda/blimp/pkg/version.Version=${VERSION} \
 	   -s -w"
 SYNCTHING_VERSION=1.4.0
 DOCKER_REPO ?= gcr.io/kelda-blimp
-DOCKER_IMAGE = ${DOCKER_REPO}/blimp:${VERSION}
+DOCKER_IMAGE = ${DOCKER_REPO}/blimp:latest
 
 # Include override variables. The production Makefile takes precendence if it exists.
 -include local.mk

--- a/scripts/upload_release.sh
+++ b/scripts/upload_release.sh
@@ -23,5 +23,3 @@ aws s3 cp ${windows_binary} s3://${s3_bucket}/${windows_binary} --acl public-rea
 # binary already exists.
 rm blimp-linux
 VERSION=${CIRCLE_TAG} make push-docker
-rm blimp-linux
-VERSION=latest make push-docker


### PR DESCRIPTION
This allows us to keep using :latest, but builds the CLI with the version set
correctly.

**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #

**How this PR was tested:**
