### PR TITLE
dockercompose: Don't join absolute build context paths

### DIFF
--- a/pkg/dockercompose/dockercompose.go
+++ b/pkg/dockercompose/dockercompose.go
@@ -128,7 +128,9 @@ func Load(composePath string, overridePaths, services []string) (types.Project, 
 			continue
 		}
 
-		cfgPtr.Services[svcIdx].Build.Context = filepath.Join(filepath.Dir(composePath), svc.Build.Context)
+		if !filepath.IsAbs(svc.Build.Context) {
+			cfgPtr.Services[svcIdx].Build.Context = filepath.Join(filepath.Dir(composePath), svc.Build.Context)
+		}
 		if svc.Build.Dockerfile == "" {
 			cfgPtr.Services[svcIdx].Build.Dockerfile = "Dockerfile"
 		}


### PR DESCRIPTION
Before, a build context of `/foo/bar` would get interpreted as `<compose
file parent>/foo/bar`.


**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #

**How this PR was tested:**