### PR TITLE
link-proxy: Fix namespace schema

### DIFF
--- a/link-proxy/main.go
+++ b/link-proxy/main.go
@@ -21,8 +21,8 @@ import (
 
 	// Importing cluster-controller/node seems bad...
 	"github.com/kelda/blimp/cluster-controller/node"
-	"github.com/kelda/blimp/pkg/kube"
 	"github.com/kelda/blimp/pkg/errors"
+	"github.com/kelda/blimp/pkg/kube"
 	nodeGRPC "github.com/kelda/blimp/pkg/proto/node"
 )
 
@@ -77,9 +77,9 @@ func main() {
 // used by our custom transport.
 func director(req *http.Request) {
 	// Make sure we don't get bamboozled into doing weird things. We expect
-	// "<namespace><token>.blimp.dev". The namespace is 32 hex characters, and
-	// the token is 8 hex characters.
-	hostRegexp := regexp.MustCompile(`^([0-9a-f]{40})\.` + regexp.QuoteMeta(LinkProxyBaseHostname) + `$`)
+	// "<namespace><token>.blimp.dev". The token is 8 hex characters, and
+	// everything before it is the namespace.
+	hostRegexp := regexp.MustCompile(`^([0-9a-z\-]+)\.` + regexp.QuoteMeta(LinkProxyBaseHostname) + `$`)
 	matches := hostRegexp.FindAllStringSubmatch(strings.ToLower(req.Host), 1)
 	if len(matches) != 1 {
 		// Host header did not match what we were expecting, abort.

--- a/link-proxy/tunnel.go
+++ b/link-proxy/tunnel.go
@@ -40,7 +40,7 @@ func (s *server) dialTunnelContext(ctx context.Context, network, addr string) (n
 	if err != nil {
 		return nil, errors.WithContext("tunnel dial parse address", err)
 	}
-	hostRegexp := regexp.MustCompile(`^([a-f0-9]{32})([a-f0-9]{8})$`)
+	hostRegexp := regexp.MustCompile(`^([a-z0-9\-]+)([a-f0-9]{8})$`)
 	matches := hostRegexp.FindStringSubmatch(host)
 	if len(matches) != 3 {
 		return nil, errors.New("unexpected namespace format: %q", host)

--- a/link-proxy/tunnel_test.go
+++ b/link-proxy/tunnel_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"google.golang.org/grpc/metadata"
@@ -25,22 +27,22 @@ func (t *mockTunnelClient) Recv() (*node.TunnelMsg, error) {
 }
 
 // Implement grpc.ClientStream. (Or rather, don't implement...)
-func(t *mockTunnelClient) Header() (metadata.MD, error) {
+func (t *mockTunnelClient) Header() (metadata.MD, error) {
 	return nil, errors.New("not implemented")
 }
-func(t *mockTunnelClient) Trailer() metadata.MD {
+func (t *mockTunnelClient) Trailer() metadata.MD {
 	return nil
 }
-func(t *mockTunnelClient) CloseSend() error {
+func (t *mockTunnelClient) CloseSend() error {
 	return errors.New("not implemented")
 }
-func(t *mockTunnelClient) Context() context.Context {
+func (t *mockTunnelClient) Context() context.Context {
 	return nil
 }
-func(t *mockTunnelClient) SendMsg(_ interface{}) error {
+func (t *mockTunnelClient) SendMsg(_ interface{}) error {
 	return errors.New("not implemented")
 }
-func(t *mockTunnelClient) RecvMsg(_ interface{}) error {
+func (t *mockTunnelClient) RecvMsg(_ interface{}) error {
 	return errors.New("not implemented")
 }
 
@@ -62,4 +64,21 @@ func TestReadPending(t *testing.T) {
 		assert.Equal(t, n, len(dest))
 		assert.EqualValues(t, dest, expected)
 	}
+}
+
+func TestDirector(t *testing.T) {
+	LinkProxyBaseHostname = "blimp.test.com"
+	input := &http.Request{
+		Host: "kevinkeldaio-e8cbfe34030f2170a6.blimp.test.com",
+		URL:  &url.URL{},
+	}
+	exp := &http.Request{
+		Host: "kevinkeldaio-e8cbfe34030f2170a6.blimp.test.com",
+		URL: &url.URL{
+			Scheme: "http",
+			Host:   "kevinkeldaio-e8cbfe34030f2170a6",
+		},
+	}
+	director(input)
+	assert.Equal(t, exp, input)
 }


### PR DESCRIPTION
A recent commit changed the namespace format to not be a fixed length,
and to have hyphens.


**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #

**How this PR was tested:**